### PR TITLE
Add support for SESSION_COOKIE_SAMESITE and SESSION_REFRESH_EACH_REQUEST

### DIFF
--- a/flask_session/sessions.py
+++ b/flask_session/sessions.py
@@ -155,11 +155,12 @@ class RedisSessionInterface(SessionInterface):
         # should be set or not.  This is controlled by the
         # SESSION_REFRESH_EACH_REQUEST config flag as well as
         # the permanent flag on the session itself.
-        # if not self.should_set_cookie(app, session):
-        #    return
+        if not self.should_set_cookie(app, session):
+            return
 
         httponly = self.get_cookie_httponly(app)
         secure = self.get_cookie_secure(app)
+        samesite = self.get_cookie_samesite(app)
         expires = self.get_expiration_time(app, session)
         val = self.serializer.dumps(dict(session))
         self.redis.setex(name=self.key_prefix + session.sid, value=val,
@@ -170,7 +171,8 @@ class RedisSessionInterface(SessionInterface):
             session_id = session.sid
         response.set_cookie(app.session_cookie_name, session_id,
                             expires=expires, httponly=httponly,
-                            domain=domain, path=path, secure=secure)
+                            domain=domain, path=path, secure=secure,
+                            samesite=samesite)
 
 
 class MemcachedSessionInterface(SessionInterface):
@@ -272,8 +274,19 @@ class MemcachedSessionInterface(SessionInterface):
                                        domain=domain, path=path)
             return
 
+        # Modification case.  There are upsides and downsides to
+        # emitting a set-cookie header each request.  The behavior
+        # is controlled by the :meth:`should_set_cookie` method
+        # which performs a quick check to figure out if the cookie
+        # should be set or not.  This is controlled by the
+        # SESSION_REFRESH_EACH_REQUEST config flag as well as
+        # the permanent flag on the session itself.
+        if not self.should_set_cookie(app, session):
+            return
+
         httponly = self.get_cookie_httponly(app)
         secure = self.get_cookie_secure(app)
+        samesite = self.get_cookie_samesite(app)
         expires = self.get_expiration_time(app, session)
         if not PY2:
             val = self.serializer.dumps(dict(session), 0)
@@ -287,7 +300,8 @@ class MemcachedSessionInterface(SessionInterface):
             session_id = session.sid
         response.set_cookie(app.session_cookie_name, session_id,
                             expires=expires, httponly=httponly,
-                            domain=domain, path=path, secure=secure)
+                            domain=domain, path=path, secure=secure,
+                            samesite=samesite)
 
 
 class FileSystemSessionInterface(SessionInterface):
@@ -347,8 +361,19 @@ class FileSystemSessionInterface(SessionInterface):
                                        domain=domain, path=path)
             return
 
+        # Modification case.  There are upsides and downsides to
+        # emitting a set-cookie header each request.  The behavior
+        # is controlled by the :meth:`should_set_cookie` method
+        # which performs a quick check to figure out if the cookie
+        # should be set or not.  This is controlled by the
+        # SESSION_REFRESH_EACH_REQUEST config flag as well as
+        # the permanent flag on the session itself.
+        if not self.should_set_cookie(app, session):
+            return
+
         httponly = self.get_cookie_httponly(app)
         secure = self.get_cookie_secure(app)
+        samesite = self.get_cookie_samesite(app)
         expires = self.get_expiration_time(app, session)
         data = dict(session)
         self.cache.set(self.key_prefix + session.sid, data,
@@ -359,7 +384,8 @@ class FileSystemSessionInterface(SessionInterface):
             session_id = session.sid
         response.set_cookie(app.session_cookie_name, session_id,
                             expires=expires, httponly=httponly,
-                            domain=domain, path=path, secure=secure)
+                            domain=domain, path=path, secure=secure,
+                            samesite=samesite)
 
 
 class MongoDBSessionInterface(SessionInterface):
@@ -432,8 +458,19 @@ class MongoDBSessionInterface(SessionInterface):
                                        domain=domain, path=path)
             return
 
+        # Modification case.  There are upsides and downsides to
+        # emitting a set-cookie header each request.  The behavior
+        # is controlled by the :meth:`should_set_cookie` method
+        # which performs a quick check to figure out if the cookie
+        # should be set or not.  This is controlled by the
+        # SESSION_REFRESH_EACH_REQUEST config flag as well as
+        # the permanent flag on the session itself.
+        if not self.should_set_cookie(app, session):
+            return
+
         httponly = self.get_cookie_httponly(app)
         secure = self.get_cookie_secure(app)
+        samesite = self.get_cookie_samesite(app)
         expires = self.get_expiration_time(app, session)
         val = self.serializer.dumps(dict(session))
         self.store.update({'id': store_id},
@@ -446,7 +483,8 @@ class MongoDBSessionInterface(SessionInterface):
             session_id = session.sid
         response.set_cookie(app.session_cookie_name, session_id,
                             expires=expires, httponly=httponly,
-                            domain=domain, path=path, secure=secure)
+                            domain=domain, path=path, secure=secure,
+                            samesite=samesite)
 
 
 class SqlAlchemySessionInterface(SessionInterface):
@@ -542,8 +580,19 @@ class SqlAlchemySessionInterface(SessionInterface):
                                        domain=domain, path=path)
             return
 
+        # Modification case.  There are upsides and downsides to
+        # emitting a set-cookie header each request.  The behavior
+        # is controlled by the :meth:`should_set_cookie` method
+        # which performs a quick check to figure out if the cookie
+        # should be set or not.  This is controlled by the
+        # SESSION_REFRESH_EACH_REQUEST config flag as well as
+        # the permanent flag on the session itself.
+        if not self.should_set_cookie(app, session):
+            return
+
         httponly = self.get_cookie_httponly(app)
         secure = self.get_cookie_secure(app)
+        samesite = self.get_cookie_samesite(app)
         expires = self.get_expiration_time(app, session)
         val = self.serializer.dumps(dict(session))
         if saved_session:
@@ -560,4 +609,5 @@ class SqlAlchemySessionInterface(SessionInterface):
             session_id = session.sid
         response.set_cookie(app.session_cookie_name, session_id,
                             expires=expires, httponly=httponly,
-                            domain=domain, path=path, secure=secure)
+                            domain=domain, path=path, secure=secure,
+                            samesite=samesite)


### PR DESCRIPTION
Upstream has a lot of code duplication in sessions.py, this PR adds more. That's not an immediate concern.